### PR TITLE
Additional functionality

### DIFF
--- a/spotify.items
+++ b/spotify.items
@@ -1,6 +1,5 @@
-
 /* Switch to Force Update */
-Switch spotify_forceupadte
+Switch spotify_forceupdate
 
 /* Strings for Primary Auth */
 String spotify_auth_code
@@ -25,6 +24,8 @@ String spotify_current_context_uri
 String spotify_current_device
 String spotify_current_device_id
 Number spotify_current_volume
+Switch spotify_current_shuffle
+String spotify_current_repeat
 
 /* Switches for Player actions */
 String spotify_action
@@ -34,3 +35,4 @@ DateTime spotify_lastConnectionDateTime
 /* Strings to store JSONs */
 
 String spotify_device_list
+String spotify_playlists

--- a/spotify.rules
+++ b/spotify.rules
@@ -1,15 +1,69 @@
-rule "Spotify run script"
+//Change play/pause
+rule "Change Spotify Play/Pause"
 when
-		Item spotify_forceupadte received update
-	then		
-			val resp =  executeCommandLine("/usr/bin/python /etc/openhab2/scripts/spotify.py", 5000)
-			logInfo("Spotify", resp)
+    Item spotify_current_playing received command
+then
+    if (spotify_current_playing.state == ON) {
+        spotify_action.sendCommand("play")
+    } else if (spotify_current_playing.state == OFF) {
+        spotify_action.sendCommand("pause")
+    }
 end
 
+//Change device
+rule "Change Spotify Device"
+when
+    Item spotify_current_device_id received command
+then
+    spotify_action.sendCommand("transfer_playback")
+end
+
+//Change volume
+rule "Set Spotify volume"
+when
+    Item spotify_current_volume received command
+then
+    spotify_action.sendCommand("volume_set " + spotify_current_volume.state.toString)
+end
+
+//Play Playlist
+rule "Play Spotify Playlist"
+when
+    Item spotify_current_context_uri received command
+then
+    spotify_action.sendCommand("play " +  spotify_current_context_uri.state.toString)
+end
+
+//Set Shuffle
+rule "Change Spotify Shuffle"
+when
+    Item spotify_current_shuffle received command
+then
+    spotify_action.sendCommand("shuffle_set " + spotify_current_shuffle.state.toString)
+end
+
+//Set Repeat
+rule "Change Spotify Repeat"
+when
+    Item spotify_current_repeat received command
+then
+    spotify_action.sendCommand("repeat_set " + spotify_current_repeat.state.toString)
+end
+
+// Update
+rule "Spotify run script"
+when
+	Item spotify_forceupdate changed to ON
+then		
+	val resp = executeCommandLine("/usr/bin/python /etc/openhab2/scripts/spotify.py", 5000)
+	logInfo("Spotify", resp)
+end
+
+//Execute Action
 rule "Spotify Action"
 when
-		Item spotify_action received update
-	then		
-			val resp =  executeCommandLine("/usr/bin/python /etc/openhab2/scripts/spotify.py " + spotify_action.state.toString, 5000)
-			logInfo("Spotify", resp)
+	Item spotify_action received update
+then		
+	val resp = executeCommandLine("/usr/bin/python /etc/openhab2/scripts/spotify.py " + spotify_action.state.toString, 5000)
+	logInfo("Spotify", resp)
 end


### PR DESCRIPTION
Added functionality of spotify.py:

1. toggle shuffle mode (shuffle_set ON/OFF)
2. toggle repeat mode (repeat_set off/track/context)
3. set volume directly additionally to in-/decreasing it (volume_set 50)
4. get up to 50 playlists an store them (get_playlists)

Added openHAB rules:

1. set play/pause
2. change device
3. set volume
4. play playlist
5. set shuffle mode
6. set repead mode

Additional items in spotify.items to make this work. Getting playlists has issues with non-ASCII symbols.